### PR TITLE
Rename clear(capacity:) to clear(minimumCapacity:)

### DIFF
--- a/Sources/NIO/ByteBuffer-core.swift
+++ b/Sources/NIO/ByteBuffer-core.swift
@@ -676,12 +676,12 @@ public struct ByteBuffer {
     ///         allocation is necessary this will be cheaper as the copy of the storage is elided.
     ///
     /// - parameters:
-    ///     - minimumNeededCapacity: The minimum capacity that will be (re)allocated for this buffer
-    public mutating func clear(capacity minimumNeededCapacity: _Capacity) {
+    ///     - minimumCapacity: The minimum capacity that will be (re)allocated for this buffer
+    public mutating func clear(minimumCapacity: _Capacity) {
         if !isKnownUniquelyReferenced(&self._storage) {
-            self._storage = self._storage.allocateStorage(capacity: minimumNeededCapacity)
-        } else if minimumNeededCapacity > self._storage.capacity {
-            self._storage.reallocStorage(capacity: minimumNeededCapacity)
+            self._storage = self._storage.allocateStorage(capacity: minimumCapacity)
+        } else if minimumCapacity > self._storage.capacity {
+            self._storage.reallocStorage(capacity: minimumCapacity)
         }
         self._slice = self._storage.fullSlice
 

--- a/Tests/NIOTests/ByteBufferTest.swift
+++ b/Tests/NIOTests/ByteBufferTest.swift
@@ -1241,7 +1241,7 @@ class ByteBufferTest: XCTestCase {
         
         XCTAssertEqual(buf1PtrVal, buf2PtrVal)
 
-        buf2.clear(capacity: 32)
+        buf2.clear(minimumCapacity: 32)
 
         buf1PtrVal = buf1.storagePointerIntegerValue()
         buf2PtrVal = buf2.storagePointerIntegerValue()
@@ -1264,7 +1264,7 @@ class ByteBufferTest: XCTestCase {
 
         XCTAssertEqual(buf1PtrVal, buf2PtrVal)
 
-        buf2.clear(capacity: 4)
+        buf2.clear(minimumCapacity: 4)
 
         buf1PtrVal = buf1.storagePointerIntegerValue()
         buf2PtrVal = buf2.storagePointerIntegerValue()
@@ -1285,7 +1285,7 @@ class ByteBufferTest: XCTestCase {
         let preCapacity = buf.capacity
 
         bufPtrValPre = buf.storagePointerIntegerValue()
-        buf.clear(capacity: 32)
+        buf.clear(minimumCapacity: 32)
         bufPtrValPost = buf.storagePointerIntegerValue()
         let postCapacity = buf.capacity
 
@@ -1305,7 +1305,7 @@ class ByteBufferTest: XCTestCase {
         XCTAssertGreaterThanOrEqual(buf.capacity, 16)
         
         bufPtrValPre = buf.storagePointerIntegerValue()
-        buf.clear(capacity: 8)
+        buf.clear(minimumCapacity: 8)
         bufPtrValPost = buf.storagePointerIntegerValue()
         let postCapacity = buf.capacity
 
@@ -1317,7 +1317,7 @@ class ByteBufferTest: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buf = alloc.buffer(capacity: 16)
 
-        buf.clear(capacity: 32)
+        buf.clear(minimumCapacity: 32)
 
         XCTAssertEqual(buf._storage.capacity, 32)
     }
@@ -1326,7 +1326,7 @@ class ByteBufferTest: XCTestCase {
         let alloc = ByteBufferAllocator()
         var buf = alloc.buffer(capacity: 16)
 
-        buf.clear(capacity: 8)
+        buf.clear(minimumCapacity: 8)
 
         XCTAssertEqual(buf._storage.capacity, 16)
     }
@@ -1336,7 +1336,7 @@ class ByteBufferTest: XCTestCase {
         var buf1 = alloc.buffer(capacity: 16)
         let buf2 = buf1
 
-        buf1.clear(capacity: 8)
+        buf1.clear(minimumCapacity: 8)
 
         XCTAssertEqual(buf1._storage.capacity, 8)
         XCTAssertEqual(buf2._storage.capacity, 16)


### PR DESCRIPTION
Incorporating the code review feedback, rename `capacity` -> `minimumCapacity` and remove `minimumNeededCapacity` because it seemed to make sense without it.